### PR TITLE
Add support for entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,19 @@ you don't need to rely on the import side-effects.
 ### <kbd>function</kbd> `catalogue.create`
 
 Create a new registry for a given namespace. Returns a setter function that can
-be used as a decorator or called with a name and `func` keyword argument.
+be used as a decorator or called with a name and `func` keyword argument. If
+`entry_points=True` is set, the registry will check for
+[Python entry points](https://packaging.python.org/tutorials/packaging-projects/#entry-points)
+advertised for the given namespace, e.g. the entry point group
+`spacy_architectures` for the namespace `"spacy", "architectures"`, and
+pre-populate the global registry. This allows other packages to auto-register
+functions.
 
-| Argument     | Type       | Description                                                            |
-| ------------ | ---------- | ---------------------------------------------------------------------- |
-| `*namespace` | str        | The namespace, e.g. `"spacy"` or `"spacy", "architectures"`.           |
-| **RETURNS**  | `Registry` | The `Registry` object with methods to register and retrieve functions. |
+| Argument       | Type       | Description                                                                                    |
+| -------------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| `*namespace`   | str        | The namespace, e.g. `"spacy"` or `"spacy", "architectures"`.                                   |
+| `entry_points` | bool       | Whether to check for entry points of the given namespace and pre-populate the global registry. |
+| **RETURNS**    | `Registry` | The `Registry` object with methods to register and retrieve functions.                         |
 
 ```python
 architectures = catalogue.create("spacy", "architectures")
@@ -133,12 +140,19 @@ usually created internally when you call `catalogue.create`.
 
 #### <kbd>method</kbd> `Registry.__init__`
 
-Initialize a new registry.
+Initialize a new registry. If `entry_points=True` is set, the registry will
+check for
+[Python entry points](https://packaging.python.org/tutorials/packaging-projects/#entry-points)
+advertised for the given namespace, e.g. the entry point group
+`spacy_architectures` for the namespace `"spacy", "architectures"`, and
+pre-populate the global registry. This allows other packages to auto-register
+functions.
 
-| Argument    | Type       | Description                                                  |
-| ----------- | ---------- | ------------------------------------------------------------ |
-| `namespace` | Tuple[str] | The namespace, e.g. `"spacy"` or `"spacy", "architectures"`. |
-| **RETURNS** | `Registry` | The newly created object.                                    |
+| Argument       | Type       | Description                                                                                    |
+| -------------- | ---------- | ---------------------------------------------------------------------------------------------- |
+| `namespace`    | Tuple[str] | The namespace, e.g. `"spacy"` or `"spacy", "architectures"`.                                   |
+| `entry_points` | bool       | Whether to check for entry points of the given namespace and pre-populate the global registry. |
+| **RETURNS**    | `Registry` | The newly created object.                                                                      |
 
 ```python
 architectures = Registry(("spacy", "architectures"))
@@ -192,6 +206,38 @@ Get all functions in the registry's namespace.
 ```python
 all_architectures = architectures.get_all()
 # {"custom_architecture": <custom_architecture>}
+```
+
+#### <kbd>method</kbd> `Registry.get_entry_points`
+
+Get registered entry points from other packages for this namespace. The name of
+the entry point group is the namespace joined by `_`.
+
+| Argument    | Type           | Description                             |
+| ----------- | -------------- | --------------------------------------- |
+| **RETURNS** | Dict[str, Any] | The loaded entry points, keyed by name. |
+
+```python
+architectures = catalog.register("spacy", "architectures", entry_points=True)
+# Will get all entry points of the group "spacy_architectures"
+all_entry_points = architectures.get_entry_points()
+```
+
+#### <kbd>method</kbd> `Registry.get_entry_point`
+
+Check if registered entry point is available for a given name in the namespace
+and load it. Otherwise, return the default value.
+
+| Argument    | Type | Description                                      |
+| ----------- | ---- | ------------------------------------------------ |
+| `name`      | str  | Name of entry point to load.                     |
+| `default`   | Any  | The default value to return. Defaults to `None`. |
+| **RETURNS** | Any  | The loaded entry point or the default value.     |
+
+```python
+architectures = catalog.register("spacy", "architectures", entry_points=True)
+# Will get entry point "custom_architecture" of the group "spacy_architectures"
+custom_architecture = architectures.get_entry_point("custom_architecture")
 ```
 
 ### <kbd>function</kbd> `catalogue.check_exists`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
       architecture: 'x64'
 
   - script: |
-      pip install -U setuptools --user
+      pip install -U -r requirements.txt
       python setup.py sdist
     displayName: 'Build sdist'
 
@@ -67,7 +67,5 @@ jobs:
       pip install dist/$SDIST
     displayName: 'Install from sdist'
 
-  - script: |
-      pip install -U pytest
-      python -m pytest test_catalogue.py
+  - script: python -m pytest test_catalogue.py
     displayName: 'Run tests'

--- a/catalogue.py
+++ b/catalogue.py
@@ -94,7 +94,7 @@ class Registry(object):
     def get_entry_points(self):
         """Get registered entry points from other packages for this namespace.
 
-        RETURNS (dict): Entry points, keyed by name.
+        RETURNS (Dict[str, Any]): Entry points, keyed by name.
         """
         result = {}
         for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):
@@ -103,10 +103,11 @@ class Registry(object):
 
     def get_entry_point(self, name, default=None):
         """Check if registered entry point is available for a given name in the
-        namespace and load it. Otherwise, return None.
+        namespace and load it. Otherwise, return the default value.
 
-        name (unicode): Name of entry point to load.
-        RETURNS: The loaded entry point or None.
+        name (str): Name of entry point to load.
+        default (Any): The default value to return.
+        RETURNS (Any): The loaded entry point or the default value.
         """
         for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):
             if entry_point.name == name:

--- a/catalogue.py
+++ b/catalogue.py
@@ -21,13 +21,14 @@ AVAILABLE_ENTRY_POINTS = importlib_metadata.entry_points()
 REGISTRY = OrderedDict()
 
 
-def create(*namespace, entry_points=False):
+def create(*namespace, **kwargs):
     """Create a new registry.
 
     *namespace (str): The namespace, e.g. "spacy" or "spacy", "architectures".
     RETURNS (Tuple[Callable]): The setter (decorator to register functions)
         and getter (to retrieve functions).
     """
+    entry_points = kwargs.get("entry_points", False)
     if check_exists(*namespace):
         raise RegistryError("Namespace already exists: {}".format(namespace))
     return Registry(namespace, entry_points=entry_points)

--- a/catalogue.py
+++ b/catalogue.py
@@ -4,17 +4,24 @@ from __future__ import unicode_literals
 from collections import OrderedDict
 import sys
 
+try:  # Python 3.8
+    import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
+
 if sys.version_info[0] == 2:
     basestring_ = basestring  # noqa: F821
 else:
     basestring_ = str
 
+# Ony ever call this once for performance reasons
+AVAILABLE_ENTRY_POINTS = importlib_metadata.entry_points()
 
 # This is where functions will be registered
 REGISTRY = OrderedDict()
 
 
-def create(*namespace):
+def create(*namespace, entry_points=False):
     """Create a new registry.
 
     *namespace (str): The namespace, e.g. "spacy" or "spacy", "architectures".
@@ -23,17 +30,22 @@ def create(*namespace):
     """
     if check_exists(*namespace):
         raise RegistryError("Namespace already exists: {}".format(namespace))
-    return Registry(namespace)
+    return Registry(namespace, entry_points=entry_points)
 
 
 class Registry(object):
-    def __init__(self, namespace):
+    def __init__(self, namespace, entry_points=False):
         """Initialize a new registry.
 
         namespace (Tuple[str]): The namespace.
+        entry_points (bool): Whether to also check for entry points.
         RETURNS (Registry): The newly created object.
         """
         self.namespace = namespace
+        self.entry_point_namespace = "_".join(namespace)
+        if entry_points:
+            for name, value in self.get_entry_points().items():
+                self.register(name, func=value)
 
     def register(self, name, **kwargs):
         """Register a function for a given namespace.
@@ -78,6 +90,28 @@ class Registry(object):
             ):
                 result[keys[-1]] = value
         return result
+
+    def get_entry_points(self):
+        """Get registered entry points from other packages for this namespace.
+
+        RETURNS (dict): Entry points, keyed by name.
+        """
+        result = {}
+        for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):
+            result[entry_point.name] = entry_point.load()
+        return result
+
+    def get_entry_point(self, name, default=None):
+        """Check if registered entry point is available for a given name in the
+        namespace and load it. Otherwise, return None.
+
+        name (unicode): Name of entry point to load.
+        RETURNS: The loaded entry point or None.
+        """
+        for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):
+            if entry_point.name == name:
+                return entry_point.load()
+        return default
 
 
 def check_exists(*namespace):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+importlib_metadata>=0.20; python_version < "3.8"
+setuptools
+pytest>=4.6.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ py_modules = catalogue
 zip_safe = true
 include_package_data = true
 python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+install_requires =
+    importlib_metadata>=0.20; python_version < "3.8"
 
 [bdist_wheel]
 universal = true

--- a/test_catalogue.py
+++ b/test_catalogue.py
@@ -87,3 +87,19 @@ def test_create_multi_namespace():
     assert items["z"] == z
     assert catalogue.check_exists("x", "y", "z")
     assert catalogue._get(("x", "y", "z")) == z
+
+
+def test_entry_points():
+    # Create a new EntryPoint object by pretending we have a config.cfg and
+    # use one of catalogue's util functions as the advertised function
+    ep_string = "[options.entry_points]test_foo\n    bar = catalogue:check_exists"
+    ep = catalogue.importlib_metadata.EntryPoint._from_text(ep_string)
+    catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = ep
+    assert catalogue.REGISTRY == {}
+    test_registry = catalogue.create("test", "foo", entry_points=True)
+    entry_points = test_registry.get_entry_points()
+    assert "bar" in entry_points
+    assert entry_points["bar"] == catalogue.check_exists
+    assert test_registry.get_entry_point("bar") == catalogue.check_exists
+    assert ("test", "foo", "bar") in catalogue.REGISTRY
+    assert catalogue._get(("test", "foo", "bar")) == catalogue.check_exists


### PR DESCRIPTION
If `entry_points=True`, initializing a `Registry` will auto-populate the global registry with functions advertised as entry points for the given namespace.

For instance, `catalogue.register("spacy", "architectures")` will look for functions advertised via the entry point group `spacy_architectures`.

## TODO

- [x] document