### PR TITLE
Allow module-like imports as entry points

### DIFF
--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -88,6 +88,10 @@ class Registry(object):
             from_entry_point = self.get_entry_point(name)
             if from_entry_point:
                 return from_entry_point
+            # load all modules in entry points to make sure we register functions from 
+            # those modules
+            for entry_point in AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, []):
+                entry_point.load()
         namespace = list(self.namespace) + [name]
         if not check_exists(*namespace):
             err = "Cant't find '{}' in registry {}. Available names: {}"


### PR DESCRIPTION
Fixes #12 

At the moment you have to point directly to functions that needs to be registered through entry points. It is not enough to just add an entry point that points to the modules where the registrations occur. This commit changes that.

I haven't added any test for this feature since I'm not exactly sure how to write that test