### PR TITLE
Work around Cython issue in registry.find

### DIFF
--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -137,7 +137,7 @@ class Registry(object):
                 return entry_point.load()
         return default
 
-    def find(self, name: str) -> Dict[str, Optional[Union[str, int]]]:
+    def find(self, name: str) -> Dict[str, Optional[Union[str, int, None]]]:
         """Find the information about a registered function, including the
         module and path to the file it's defined in, the line number and the
         docstring, if available.

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -146,12 +146,18 @@ class Registry(object):
         RETURNS (Dict[str, Optional[Union[str, int]]]): The function info.
         """
         func = self.get(name)
-        _, line_no = inspect.getsourcelines(func)
         module = inspect.getmodule(func)
+        # These calls will fail for Cython modules so we need to work around them
+        try:
+            _, line_no = inspect.getsourcelines(func)
+            file_name = inspect.getfile(func)
+        except (TypeError, ValueError):
+            line_no = None
+            file_name = None
         docstring = inspect.getdoc(func)
         return {
             "module": module.__name__ if module else None,
-            "file": inspect.getfile(func),
+            "file": file_name,
             "line_no": line_no,
             "docstring": inspect.cleandoc(docstring) if docstring else None,
         }

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -137,7 +137,7 @@ class Registry(object):
                 return entry_point.load()
         return default
 
-    def find(self, name: str) -> Dict[str, Optional[Union[str, int, None]]]:
+    def find(self, name: str) -> Dict[str, Optional[Union[str, int]]]:
         """Find the information about a registered function, including the
         module and path to the file it's defined in, the line number and the
         docstring, if available.
@@ -148,12 +148,13 @@ class Registry(object):
         func = self.get(name)
         module = inspect.getmodule(func)
         # These calls will fail for Cython modules so we need to work around them
+        line_no: Optional[int] = None
+        file_name: Optional[str] = None
         try:
             _, line_no = inspect.getsourcelines(func)
             file_name = inspect.getfile(func)
         except (TypeError, ValueError):
-            line_no = None
-            file_name = None
+            pass
         docstring = inspect.getdoc(func)
         return {
             "module": module.__name__ if module else None,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-version = 2.0.5
+version = 2.0.6
 description = Super lightweight function registries for your library
 url = https://github.com/explosion/catalogue
 author = Explosion


### PR DESCRIPTION
Certain `inspect` methods will raise an error if the function is defined in Cython.

```
TypeError: module, class, method, function, traceback, frame, or code object was expected, got cython_function_or_method
```

This PR works around this by setting the values we can't get to `None`. Tested this with spaCy and it now works for all component factories, including those that previously failed (e.g. `tagger.pyx`).