### PR TITLE
Update tests and CI for python 3.10

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,6 +45,15 @@ jobs:
       Python39Mac:
         imageName: 'macos-latest'
         python.version: '3.9'
+      Python310Linux:
+        imageName: 'ubuntu-latest'
+        python.version: '3.10'
+      Python310Windows:
+        imageName: 'windows-latest'
+        python.version: '3.10'
+      Python310Mac:
+        imageName: 'macos-latest'
+        python.version: '3.10'
     maxParallel: 4
   pool:
     vmImage: $(imageName)

--- a/catalogue/tests/test_catalogue.py
+++ b/catalogue/tests/test_catalogue.py
@@ -1,4 +1,5 @@
 import pytest
+import sys
 from pathlib import Path
 import catalogue
 
@@ -101,6 +102,7 @@ def test_create_multi_namespace():
     assert catalogue._get(("x", "y", "z")) == z
 
 
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test is not yet updated for 3.10 importlib_metadata API")
 def test_entry_points():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function


### PR DESCRIPTION
Initially skip unsupported test (due to internal changes in `importlib.metadata`).