### PR TITLE
Use EntryPoint backport in tests for python 3.10

### DIFF
--- a/catalogue/tests/test_catalogue.py
+++ b/catalogue/tests/test_catalogue.py
@@ -2,6 +2,7 @@ import pytest
 import sys
 from pathlib import Path
 import catalogue
+from catalogue._importlib_metadata import EntryPoint as BackportEntryPoint
 
 
 @pytest.fixture(autouse=True)
@@ -102,12 +103,11 @@ def test_create_multi_namespace():
     assert catalogue._get(("x", "y", "z")) == z
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test is not yet updated for 3.10 importlib_metadata API")
 def test_entry_points():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function
     ep_string = "[options.entry_points]test_foo\n    bar = catalogue:check_exists"
-    ep = catalogue.importlib_metadata.EntryPoint._from_text(ep_string)
+    ep = BackportEntryPoint._from_text(ep_string)
     catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = ep
     assert catalogue.REGISTRY == {}
     test_registry = catalogue.create("test", "foo", entry_points=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-zipp>=0.5; python_version < "3.8"
-typing-extensions>=3.6.4; python_version < "3.8"
+zipp>=0.5
+typing-extensions>=3.6.4
 pytest>=4.6.5
 mypy


### PR DESCRIPTION
This is initially in order to run the entry points test in python 3.10 so that it's easier to address the deprecation warnings.