### PR TITLE
Update for python 3.10+: branch on SelectableGroups

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,7 @@ jobs:
   - script: python -m pip install -U -r requirements.txt
     displayName: "Install test requirements"
 
-  - script: python -m pytest --pyargs catalogue
+  - script: python -m pytest --pyargs catalogue -Werror
     displayName: 'Run tests'
 
   - bash: |

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -149,7 +149,7 @@ class Registry(object):
 
     def _get_entry_points(self) -> List[importlib_metadata.EntryPoint]:
         if isinstance(AVAILABLE_ENTRY_POINTS, SelectableGroups):
-            return cast(SelectableGroups, AVAILABLE_ENTRY_POINTS).select(group=self.entry_point_namespace)
+            return AVAILABLE_ENTRY_POINTS.select(group=self.entry_point_namespace)
         else:  # dict
             return AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, [])
 

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -1,4 +1,4 @@
-from typing import Sequence, Any, Dict, Tuple, Callable, Optional, TypeVar
+from typing import Sequence, Any, Dict, Tuple, Callable, Optional, TypeVar, cast
 from typing import List, Union
 import inspect
 
@@ -149,7 +149,7 @@ class Registry(object):
 
     def _get_entry_points(self) -> List[importlib_metadata.EntryPoint]:
         if isinstance(AVAILABLE_ENTRY_POINTS, SelectableGroups):
-            return AVAILABLE_ENTRY_POINTS.select(group=self.entry_point_namespace)
+            return cast(AVAILABLE_ENTRY_POINTS, SelectableGroups).select(group=self.entry_point_namespace)
         else:  # dict
             return AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, [])
 

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -149,7 +149,7 @@ class Registry(object):
 
     def _get_entry_points(self) -> List[importlib_metadata.EntryPoint]:
         if isinstance(AVAILABLE_ENTRY_POINTS, SelectableGroups):
-            return cast(AVAILABLE_ENTRY_POINTS, SelectableGroups).select(group=self.entry_point_namespace)
+            return cast(SelectableGroups, AVAILABLE_ENTRY_POINTS).select(group=self.entry_point_namespace)
         else:  # dict
             return AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, [])
 

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -1,5 +1,5 @@
-from typing import Sequence, Any, Dict, Tuple, Callable, Optional, TypeVar, cast
-from typing import List, Union
+from typing import Sequence, Any, Dict, Tuple, Callable, Optional, TypeVar, Union
+from typing import List
 import inspect
 
 try:  # Python 3.8

--- a/catalogue/tests/test_catalogue.py
+++ b/catalogue/tests/test_catalogue.py
@@ -102,13 +102,8 @@ def test_create_multi_namespace():
     assert catalogue._get(("x", "y", "z")) == z
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test does not support >=3.10 importlib_metadata API")
-def test_entry_points_older():
-    # Create a new EntryPoint object by pretending we have a setup.cfg and
-    # use one of catalogue's util functions as the advertised function
-    ep_string = "[options.entry_points]test_foo\n    bar = catalogue:check_exists"
-    ep = catalogue.importlib_metadata.EntryPoint._from_text(ep_string)
-    catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = ep
+def _check_entry_points():
+    # Check entry points for test_entry_points_older() and test_entry_points_newer().
     assert catalogue.REGISTRY == {}
     test_registry = catalogue.create("test", "foo", entry_points=True)
     entry_points = test_registry.get_entry_points()
@@ -119,6 +114,16 @@ def test_entry_points_older():
     assert test_registry.get("bar") == catalogue.check_exists
     assert test_registry.get_all() == {"bar": catalogue.check_exists}
     assert "bar" in test_registry
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test does not support >=3.10 importlib_metadata API")
+def test_entry_points_older():
+    # Create a new EntryPoint object by pretending we have a setup.cfg and
+    # use one of catalogue's util functions as the advertised function
+    ep_string = "[options.entry_points]test_foo\n    bar = catalogue:check_exists"
+    ep = catalogue.importlib_metadata.EntryPoint._from_text(ep_string)
+    catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = ep
+    _check_entry_points()
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Test does not support <3.10 importlib_metadata API")
@@ -127,16 +132,7 @@ def test_entry_points_newer():
     # use one of catalogue's util functions as the advertised function
     ep = catalogue.importlib_metadata.EntryPoint("bar", "catalogue:check_exists", "test_foo")
     catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = catalogue.importlib_metadata.EntryPoints([ep])
-    assert catalogue.REGISTRY == {}
-    test_registry = catalogue.create("test", "foo", entry_points=True)
-    entry_points = test_registry.get_entry_points()
-    assert "bar" in entry_points
-    assert entry_points["bar"] == catalogue.check_exists
-    assert test_registry.get_entry_point("bar") == catalogue.check_exists
-    assert catalogue.REGISTRY == {}
-    assert test_registry.get("bar") == catalogue.check_exists
-    assert test_registry.get_all() == {"bar": catalogue.check_exists}
-    assert "bar" in test_registry
+    _check_entry_points()
 
 
 def test_registry_find():

--- a/catalogue/tests/test_catalogue.py
+++ b/catalogue/tests/test_catalogue.py
@@ -116,7 +116,10 @@ def _check_entry_points():
     assert "bar" in test_registry
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test does not support >=3.10 importlib_metadata API")
+@pytest.mark.skipif(
+    sys.version_info >= (3, 10),
+    reason="Test does not support >=3.10 importlib_metadata API",
+)
 def test_entry_points_older():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function
@@ -126,12 +129,19 @@ def test_entry_points_older():
     _check_entry_points()
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="Test does not support <3.10 importlib_metadata API")
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="Test does not support <3.10 importlib_metadata API",
+)
 def test_entry_points_newer():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function
-    ep = catalogue.importlib_metadata.EntryPoint("bar", "catalogue:check_exists", "test_foo")
-    catalogue.AVAILABLE_ENTRY_POINTS["test_foo"] = catalogue.importlib_metadata.EntryPoints([ep])
+    ep = catalogue.importlib_metadata.EntryPoint(
+        "bar", "catalogue:check_exists", "test_foo"
+    )
+    catalogue.AVAILABLE_ENTRY_POINTS[
+        "test_foo"
+    ] = catalogue.importlib_metadata.EntryPoints([ep])
     _check_entry_points()
 
 

--- a/catalogue/tests/test_catalogue.py
+++ b/catalogue/tests/test_catalogue.py
@@ -103,7 +103,7 @@ def test_create_multi_namespace():
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 10), reason="Test does not support >=3.10 importlib_metadata API")
-def test_entry_points_newer():
+def test_entry_points_older():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function
     ep_string = "[options.entry_points]test_foo\n    bar = catalogue:check_exists"
@@ -122,7 +122,7 @@ def test_entry_points_newer():
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10), reason="Test does not support <3.10 importlib_metadata API")
-def test_entry_points_older():
+def test_entry_points_newer():
     # Create a new EntryPoint object by pretending we have a setup.cfg and
     # use one of catalogue's util functions as the advertised function
     ep = catalogue.importlib_metadata.EntryPoint("bar", "catalogue:check_exists", "test_foo")


### PR DESCRIPTION
- Branch on presence of `SelectableGroups` when retrieving entry points
- Branch on python version in tests when creating dummy entry points