### PR TITLE
`Registry`: Optimize `get_all`

### DIFF
--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -116,7 +116,8 @@ class Registry(object):
         result = {}
         if self.entry_points:
             result.update(self.get_entry_points())
-        for keys, value in REGISTRY.items():
+        # Create a copy of the global registry in case it gets modified during iteration.
+        for keys, value in REGISTRY.copy().items():
             if len(self.namespace) == len(keys) - 1 and keys[:-1] == self.namespace:
                 result[keys[-1]] = value
         return result

--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -108,19 +108,16 @@ class Registry(object):
         return _get(namespace)
 
     def get_all(self) -> Dict[str, Any]:
-        """Get a all functions for a given namespace.
+        """Get all functions belonging to this registry's namespace.
 
-        namespace (Tuple[str]): The namespace to get.
         RETURNS (Dict[str, Any]): The functions, keyed by name.
         """
         global REGISTRY
         result = {}
         if self.entry_points:
             result.update(self.get_entry_points())
-        for keys, value in REGISTRY.copy().items():
-            if len(self.namespace) == len(keys) - 1 and all(
-                self.namespace[i] == keys[i] for i in range(len(self.namespace))
-            ):
+        for keys, value in REGISTRY.items():
+            if len(self.namespace) == len(keys) - 1 and keys[:-1] == self.namespace:
                 result[keys[-1]] = value
         return result
 


### PR DESCRIPTION
Remove superfluous copy of the global registry object and use tuple hashes for namespace comparisons.

This function was turning up in pipeline profiles due its use in the [`msgpack` deserialization code](https://github.com/explosion/srsly/blob/2e59c9a3cda1e37c64e575379b0b78f69dede464/srsly/msgpack/__init__.py#L76), which is often called in hot prediction/training loops.