### PR TITLE
Update Entry Points Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ you don't need to rely on the import side-effects.
 Create a new registry for a given namespace. Returns a setter function that can
 be used as a decorator or called with a name and `func` keyword argument. If
 `entry_points=True` is set, the registry will check for
-[Python entry points](https://packaging.python.org/tutorials/packaging-projects/#entry-points)
+[Python entry points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
 advertised for the given namespace, e.g. the entry point group
 `spacy_architectures` for the namespace `"spacy", "architectures"`, in
 `Registry.get` and `Registry.get_all`. This allows other packages to

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ you don't need to rely on the import side-effects.
 Create a new registry for a given namespace. Returns a setter function that can
 be used as a decorator or called with a name and `func` keyword argument. If
 `entry_points=True` is set, the registry will check for
-[Python entry points](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)
+[Python entry points](https://packaging.python.org/en/latest/specifications/entry-points)
 advertised for the given namespace, e.g. the entry point group
 `spacy_architectures` for the namespace `"spacy", "architectures"`, in
 `Registry.get` and `Registry.get_all`. This allows other packages to


### PR DESCRIPTION
There's a link in the README that is supposed to point to some supporting documentation about entry points, but doesn't. 

Searching the python packaging docs led me to [here](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/?highlight=entry%20points#entry-points), which points a user to the included link to the setuptools docs for more information ([link](https://setuptools.pypa.io/en/latest/userguide/entry_point.html)).