### PR TITLE
Switch from SelectableGroups to hasattr for importlib.metadata branching

### DIFF
--- a/catalogue/__init__.py
+++ b/catalogue/__init__.py
@@ -3,15 +3,6 @@ from typing import List
 import inspect
 import importlib.metadata
 
-try:  # Python 3.10
-    from importlib.metadata import SelectableGroups  # type: ignore
-except ImportError:
-
-    class _NotImplemented:
-        pass
-
-    SelectableGroups = _NotImplemented  # type: ignore
-
 # Only ever call this once for performance reasons
 AVAILABLE_ENTRY_POINTS = importlib.metadata.entry_points()  # type: ignore
 
@@ -142,7 +133,7 @@ class Registry(object):
         return default
 
     def _get_entry_points(self) -> List[importlib.metadata.EntryPoint]:
-        if isinstance(AVAILABLE_ENTRY_POINTS, SelectableGroups):
+        if hasattr(AVAILABLE_ENTRY_POINTS, "select"):
             return AVAILABLE_ENTRY_POINTS.select(group=self.entry_point_namespace)
         else:  # dict
             return AVAILABLE_ENTRY_POINTS.get(self.entry_point_namespace, [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pytest>=4.6.5
-mypy
+mypy>=0.991


### PR DESCRIPTION
`SelectableGroups` is no longer in python 3.12 and the original reason for this design was the lack of support for `hasattr` for mypy, which has since been resolved.